### PR TITLE
fix hasFcTrack for photons

### DIFF
--- a/tools/event_dump/python/Collector.py
+++ b/tools/event_dump/python/Collector.py
@@ -171,6 +171,7 @@ class Collector( Algorithm ):
       elCont    = context.getHandler( "PhotonContainer" )
       trkCont   = None
       hasTrack  = False
+      hasFcTrack = False
 
     eventInfo = context.getHandler( "EventInfoContainer" )
     fc        = context.getHandler( "HLT__TrigEMClusterContainer" )


### PR DESCRIPTION
Fixing bug to Photon Dataframe (hasFcTrack was not initialized when used the Photon_v1 schema)