### PR TITLE
add hlt variables into ImpactTool, fix the TrigElectron container in Chain.py and allow memory growth in tensorflow

### DIFF
--- a/trigger/python/RingerSelectorTool.py
+++ b/trigger/python/RingerSelectorTool.py
@@ -9,6 +9,8 @@ from EventAtlas import Accept
 import numpy as np
 import tensorflow as tf
 
+import os 
+os.environ['TF_FORCE_GPU_ALLOW_GROWTH'] = 'true'
 
 #
 # Hypo tool

--- a/trigger/python/menu/Chain.py
+++ b/trigger/python/menu/Chain.py
@@ -197,7 +197,7 @@ class Chain( Algorithm ):
 
 
     if self.__trigInfo.signature() == 'electron':
-      cont = context.getHandler("HLT__FastElectronContainer")
+      cont = context.getHandler("HLT__TrigElectronContainer")
     else:
       cont = context.getHandler("HLT__PhotonContainer")
 


### PR DESCRIPTION
This pull request has little modifications:

1. Addition of hlt variables into the ImpactTool in order to compare the differences between the offline and the hlt;
2. A little issue related to the naming of `HLT__TrigElectronContainer` which is used in Chain.py on line 200 and was incorrect place as `HLT__FastElectronContainer`.
3. Set `TF_FORCE_GPU_ALLOW_GROWTH` to true in RingerSelectorTool.py in order to allow growth memory when using tensorflow

No more modifications were made.